### PR TITLE
Map from empty level 2 (and above) source

### DIFF
--- a/Source/UnitTests/Mappings/MappingWithConfigTests.cs
+++ b/Source/UnitTests/Mappings/MappingWithConfigTests.cs
@@ -122,7 +122,22 @@ namespace UnitTests.Mappings
             Assert.Equal("7788", result.C2Name1);
             Assert.Equal("7788", result.C2Name2);
         }
-        
+
+        [Fact]
+        public void Map_EmptyLevel2Source_IsNull()
+        {
+            TinyMapper.Bind<Source3, Target1>(config =>
+            {
+                config.Bind(from => from.Name.CName, to => to.MyString);
+            });
+
+            var source = new Source3();
+
+            var actual = TinyMapper.Map<Target1>(source);
+
+            Assert.Null(actual.MyString);
+        }
+
         public class SourceName
         {
             public string CName { get; set; }
@@ -150,6 +165,11 @@ namespace UnitTests.Mappings
         {
             public IList<int> Ints { get; set; }
             public List<string> Strings { get; set; }
+        }
+
+        public class Source3
+        {
+            public SourceName Name { get; set; }
         }
 
         public class SourceItem


### PR DESCRIPTION
Hi @GSerjo

Is it possible to support null-check for parent level properties in the  MapClass method generated in the dynamic mapper:

This is the MapClass pseudo method, as it would be generated right now:
```
protected override MappingWithConfigTests.Target1 MapClass(
  MappingWithConfigTests.Source3 obj0,
  MappingWithConfigTests.Target1 obj1)
{
  obj1.MyString = obj0.Name.get_CName();
  return obj1;
}
```

Could the following be possible instead:
```
protected override MappingWithConfigTests.Target1 MapClass(
  MappingWithConfigTests.Source3 obj0,
  MappingWithConfigTests.Target1 obj1)
{
  obj1.MyString = ((obj0.Name != null) ? obj0.Name.get_CName() : null);
  return obj1;
}
```

This would result in mapping a null value instead of throwing a NullReferenceException, which in my opinion, is a correct mapping behavior.

I have looked into the ILGenerator implementation, but I simply can't figure out, how and where to emit the commands.

What is your opinion on this approach and can you help me accomplish this?

I have added a unit test (in this PR), that fails right now, but when the proposed change above is done, it should succeed